### PR TITLE
Center log save toast notification

### DIFF
--- a/log-ui.js
+++ b/log-ui.js
@@ -723,12 +723,13 @@ function showToast(message, type = 'success') {
     const toast = document.createElement('div');
     toast.className = `toast ${type}`;
     toast.textContent = message;
-    
+
     // 添加样式
     toast.style.cssText = `
         position: fixed;
         top: 20px;
-        right: 20px;
+        left: 50%;
+        transform: translate(-50%, -20px);
         padding: 12px 24px;
         border-radius: 4px;
         color: white;
@@ -737,22 +738,22 @@ function showToast(message, type = 'success') {
         background: ${type === 'error' ? '#e74c3c' : '#27ae60'};
         box-shadow: 0 2px 8px rgba(0,0,0,0.2);
         opacity: 0;
-        transform: translateX(100%);
+        display: inline-block;
         transition: all 0.3s ease;
     `;
-    
+
     document.body.appendChild(toast);
-    
+
     // 显示动画
     setTimeout(() => {
         toast.style.opacity = '1';
-        toast.style.transform = 'translateX(0)';
+        toast.style.transform = 'translate(-50%, 0)';
     }, 100);
-    
+
     // 自动隐藏
     setTimeout(() => {
         toast.style.opacity = '0';
-        toast.style.transform = 'translateX(100%)';
+        toast.style.transform = 'translate(-50%, -20px)';
         setTimeout(() => {
             document.body.removeChild(toast);
         }, 300);

--- a/styles.css
+++ b/styles.css
@@ -1574,7 +1574,7 @@ button svg {
 
 /* Utility */
 .badge { display: inline-block; font-size: 12px; padding: 3px 8px; border-radius: 999px; background: #eee; color: #333; }
-.toast { position: fixed; bottom: 20px; right: 20px; background: #333; color: #fff; padding: 10px 14px; border-radius: 6px; opacity: 0.95; }
+.toast { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); background: #333; color: #fff; padding: 10px 14px; border-radius: 6px; opacity: 0.95; display: inline-block; z-index: 10000; }
 
 .close-button {
     background: transparent;


### PR DESCRIPTION
## Summary
- Reposition log save notifications as small toasts near the top center of the screen
- Update toast styles to avoid full-height overlays and ensure compact display

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc387012b4832eb84fad8a1066173f