### PR TITLE
Enhance trade modal styling and navigation

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -183,7 +183,9 @@ export function showTradeDetails(date) {
     });
 
     // 设置模态框标题和统计信息
-    document.getElementById('modalDate').textContent = date.toLocaleDateString();
+    const dateEl = document.getElementById('modalDate');
+    dateEl.textContent = date.toLocaleDateString();
+    dateEl.dataset.date = dateStr;
 
     // 计算统计数据
     const consolidatedArray = Array.from(consolidatedTrades.values());
@@ -223,6 +225,31 @@ export function showTradeDetails(date) {
 
     // 在交易详情中渲染日志内容
     displayLogInTradeModal(date);
+
+    // 设置前后交易日导航
+    const tradeDates = Array.from(new Set(allTrades
+        .filter(t => t['Open/CloseIndicator'] === 'C')
+        .map(t => t.TradeDate)
+    )).sort();
+    const currentIndex = tradeDates.indexOf(dateStr);
+    const prevBtn = document.getElementById('prevTradeDay');
+    const nextBtn = document.getElementById('nextTradeDay');
+    if (prevBtn) {
+        prevBtn.style.display = currentIndex > 0 ? 'block' : 'none';
+        prevBtn.onclick = () => {
+            if (currentIndex > 0) {
+                showTradeDetails(new Date(tradeDates[currentIndex - 1]));
+            }
+        };
+    }
+    if (nextBtn) {
+        nextBtn.style.display = currentIndex < tradeDates.length - 1 ? 'block' : 'none';
+        nextBtn.onclick = () => {
+            if (currentIndex < tradeDates.length - 1) {
+                showTradeDetails(new Date(tradeDates[currentIndex + 1]));
+            }
+        };
+    }
 
     if (modal) {
         modal.style.display = 'block';

--- a/index.html
+++ b/index.html
@@ -129,42 +129,46 @@
 <!-- 添加交易详情弹窗 -->
 <div id="tradeModal" class="trade-modal">
     <div class="trade-modal-content">
+        <span class="close-button" id="closeTradeModalBtn">&times;</span>
         <div class="modal-header">
-            <h2 id="modalDate"></h2>
-            <h2 id="modalNetPnL"></h2>
+            <span id="modalDate" class="modal-date"></span>
+            <span id="modalNetPnL" class="modal-pnl"></span>
         </div>
         <div class="trade-stats">
-            <div>
-                <span>Total Trades: </span><span id="modalTotalTrades"></span>
-                <span>Winners: </span><span id="modalWinners"></span>
-                <span>Winrate: </span><span id="modalWinrate"></span>
+            <div class="stats-row">
+                <span class="stat-label">Total Trades:</span><span id="modalTotalTrades" class="stat-value"></span>
+                <span class="stat-label">Winners:</span><span id="modalWinners" class="stat-value"></span>
+                <span class="stat-label">Winrate:</span><span id="modalWinrate" class="stat-value"></span>
             </div>
-            <div>
-                <span>Losers: </span><span id="modalLosers"></span>
-                <span>Volume: </span><span id="modalVolume"></span>
-                <span>Profit Factor: </span><span id="modalProfitFactor"></span>
+            <div class="stats-row">
+                <span class="stat-label">Losers:</span><span id="modalLosers" class="stat-value"></span>
+                <span class="stat-label">Volume:</span><span id="modalVolume" class="stat-value"></span>
+                <span class="stat-label">Profit Factor:</span><span id="modalProfitFactor" class="stat-value"></span>
             </div>
         </div>
-        <table class="trades-table">
-            <thead>
-                <tr>
-                    <th>Open Time</th>
-                    <th>Ticker</th>
-                    <th>Side</th>
-                    <th>Instrument</th>
-                    <th>Net P&L</th>
-                    <th>Net ROI</th>
-                    <th>Trade Times</th>
-                    <th>Playbook</th>
-                </tr>
-            </thead>
-            <tbody id="tradesTableBody">
-            </tbody>
-        </table>
-        <div class="button-group">
-            <button class="cancel-button" id="closeTradeModalBtn">Cancel</button>
-            <button class="details-button" id="viewDetailsBtn">View Details</button>
+        <div class="table-wrapper">
+            <div class="table-controls">
+                <button class="details-button" id="viewDetailsBtn">View Details</button>
+            </div>
+            <table class="trades-table">
+                <thead>
+                    <tr>
+                        <th>Open Time</th>
+                        <th>Ticker</th>
+                        <th>Side</th>
+                        <th>Instrument</th>
+                        <th>Net P&L</th>
+                        <th>Net ROI</th>
+                        <th>Trade Times</th>
+                        <th>Playbook</th>
+                    </tr>
+                </thead>
+                <tbody id="tradesTableBody">
+                </tbody>
+            </table>
         </div>
+        <button class="nav-arrow left" id="prevTradeDay">&larr;</button>
+        <button class="nav-arrow right" id="nextTradeDay">&rarr;</button>
     </div>
 </div>
 <div class="stats-container">

--- a/styles.css
+++ b/styles.css
@@ -2174,6 +2174,85 @@ button svg {
     background: #2980b9;
 }
 
+.trade-modal-content {
+    position: relative;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 10px;
+}
+
+.modal-date {
+    font-size: 24px;
+    font-weight: 600;
+    color: #333;
+}
+
+.modal-pnl {
+    font-size: 20px;
+}
+
+.profit { color: #2e7d32; }
+.fail { color: #c62828; }
+
+.trade-stats {
+    margin: 10px 0 20px;
+}
+
+.trade-stats .stats-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-bottom: 5px;
+}
+
+.trade-stats .stat-label {
+    color: #666;
+    margin-right: 4px;
+}
+
+.trade-stats .stat-value {
+    font-weight: 600;
+    color: #333;
+}
+
+.table-wrapper {
+    margin-top: 10px;
+}
+
+.table-controls {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 5px;
+}
+
+.trades-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.trades-table th,
+.trades-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+.nav-arrow {
+    position: absolute;
+    bottom: 10px;
+    background: transparent;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.nav-arrow.left { left: 10px; }
+.nav-arrow.right { right: 10px; }
+
 .close-button {
     background: transparent;
     color: #333;


### PR DESCRIPTION
## Summary
- align date and Net P&L in modal header with color-coded profits/losses
- restyle trade statistics and table with borders and relocate View Details button
- add top-right close icon and navigation arrows for browsing trading days

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bc3f937094832eb1c35683440e0468