### PR TITLE
fix: adjust trade modal styles

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -194,7 +194,13 @@ export function showTradeDetails(date) {
     const winrate = consolidatedArray.length ? (winners / consolidatedArray.length * 100).toFixed(2) : '0.00';
 
     // 更新统计信息显示
-    document.getElementById('modalNetPnL').innerHTML = `Net P&L ${formatPnL(totalPnL)}`;
+    const netPnLEl = document.getElementById('modalNetPnL');
+    if (netPnLEl) {
+        netPnLEl.classList.remove('profit', 'fail');
+        netPnLEl.classList.add(totalPnL >= 0 ? 'profit' : 'fail');
+        const prefix = totalPnL >= 0 ? '+' : '';
+        netPnLEl.textContent = `Net P&L ${prefix}$${totalPnL.toFixed(2)}`;
+    }
     document.getElementById('modalTotalTrades').textContent = consolidatedArray.length;
     document.getElementById('modalWinners').textContent = winners;
     document.getElementById('modalLosers').textContent = consolidatedArray.length - winners;
@@ -285,7 +291,10 @@ export function closeTradeModal() {
         const dateEl = document.getElementById('modalDate');
         if (dateEl) dateEl.textContent = '';
         const netEl = document.getElementById('modalNetPnL');
-        if (netEl) netEl.innerHTML = '';
+        if (netEl) {
+            netEl.textContent = '';
+            netEl.classList.remove('profit', 'fail');
+        }
         const totalEl = document.getElementById('modalTotalTrades');
         if (totalEl) totalEl.textContent = '';
         const winEl = document.getElementById('modalWinners');

--- a/index.html
+++ b/index.html
@@ -167,8 +167,10 @@
                 </tbody>
             </table>
         </div>
-        <button class="nav-arrow left" id="prevTradeDay">&larr;</button>
-        <button class="nav-arrow right" id="nextTradeDay">&rarr;</button>
+        <div class="trade-nav">
+            <button class="nav-arrow left" id="prevTradeDay">&larr;</button>
+            <button class="nav-arrow right" id="nextTradeDay">&rarr;</button>
+        </div>
     </div>
 </div>
 <div class="stats-container">

--- a/styles.css
+++ b/styles.css
@@ -2232,6 +2232,7 @@ button svg {
 .trades-table {
     width: 100%;
     border-collapse: collapse;
+    border: 1px solid #ddd;
 }
 
 .trades-table th,
@@ -2241,17 +2242,18 @@ button svg {
     text-align: left;
 }
 
+.trade-nav {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
 .nav-arrow {
-    position: absolute;
-    bottom: 10px;
     background: transparent;
     border: none;
     font-size: 24px;
     cursor: pointer;
 }
-
-.nav-arrow.left { left: 10px; }
-.nav-arrow.right { right: 10px; }
 
 .close-button {
     background: transparent;


### PR DESCRIPTION
## Summary
- ensure trade modal net P&L text uses profit/fail colors
- show trade table borders by default and align day navigation arrows horizontally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc443e6938832e85aaac2adcf3303e