### PR TITLE
修复交易详情弹窗导航与统计显示

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -192,6 +192,10 @@ export function showTradeDetails(date) {
     const totalPnL = consolidatedArray.reduce((sum, trade) => sum + trade.FifoPnlRealized, 0);
     const winners = consolidatedArray.filter(trade => trade.FifoPnlRealized > 0).length;
     const winrate = consolidatedArray.length ? (winners / consolidatedArray.length * 100).toFixed(2) : '0.00';
+    const totalVolume = consolidatedArray.reduce((sum, trade) => sum + trade.Quantity, 0);
+    const totalProfits = consolidatedArray.reduce((sum, t) => t.FifoPnlRealized > 0 ? sum + t.FifoPnlRealized : sum, 0);
+    const totalLosses = consolidatedArray.reduce((sum, t) => t.FifoPnlRealized < 0 ? sum + Math.abs(t.FifoPnlRealized) : sum, 0);
+    const profitFactor = totalLosses === 0 ? totalProfits : totalProfits / totalLosses;
 
     // 更新统计信息显示
     const netPnLEl = document.getElementById('modalNetPnL');
@@ -205,6 +209,8 @@ export function showTradeDetails(date) {
     document.getElementById('modalWinners').textContent = winners;
     document.getElementById('modalLosers').textContent = consolidatedArray.length - winners;
     document.getElementById('modalWinrate').textContent = `${winrate}%`;
+    document.getElementById('modalVolume').textContent = totalVolume;
+    document.getElementById('modalProfitFactor').textContent = profitFactor.toFixed(2);
 
     // 填充交易表格
     const tableBody = document.getElementById('tradesTableBody');
@@ -241,7 +247,7 @@ export function showTradeDetails(date) {
     const prevBtn = document.getElementById('prevTradeDay');
     const nextBtn = document.getElementById('nextTradeDay');
     if (prevBtn) {
-        prevBtn.style.display = currentIndex > 0 ? 'block' : 'none';
+        prevBtn.style.display = currentIndex > 0 ? 'inline-block' : 'none';
         prevBtn.onclick = () => {
             if (currentIndex > 0) {
                 showTradeDetails(new Date(tradeDates[currentIndex - 1]));
@@ -249,7 +255,7 @@ export function showTradeDetails(date) {
         };
     }
     if (nextBtn) {
-        nextBtn.style.display = currentIndex < tradeDates.length - 1 ? 'block' : 'none';
+        nextBtn.style.display = currentIndex < tradeDates.length - 1 ? 'inline-block' : 'none';
         nextBtn.onclick = () => {
             if (currentIndex < tradeDates.length - 1) {
                 showTradeDetails(new Date(tradeDates[currentIndex + 1]));
@@ -303,6 +309,10 @@ export function closeTradeModal() {
         if (loseEl) loseEl.textContent = '';
         const winrateEl = document.getElementById('modalWinrate');
         if (winrateEl) winrateEl.textContent = '';
+        const volumeEl = document.getElementById('modalVolume');
+        if (volumeEl) volumeEl.textContent = '';
+        const pfEl = document.getElementById('modalProfitFactor');
+        if (pfEl) pfEl.textContent = '';
 
         const tableBody = document.getElementById('tradesTableBody');
         if (tableBody) {

--- a/index.html
+++ b/index.html
@@ -131,7 +131,11 @@
     <div class="trade-modal-content">
         <span class="close-button" id="closeTradeModalBtn">&times;</span>
         <div class="modal-header">
-            <span id="modalDate" class="modal-date"></span>
+            <div class="date-nav">
+                <button class="nav-arrow left" id="prevTradeDay">&larr;</button>
+                <span id="modalDate" class="modal-date"></span>
+                <button class="nav-arrow right" id="nextTradeDay">&rarr;</button>
+            </div>
             <span id="modalNetPnL" class="modal-pnl"></span>
         </div>
         <div class="trade-stats">
@@ -139,8 +143,6 @@
                 <span class="stat-label">Total Trades:</span><span id="modalTotalTrades" class="stat-value"></span>
                 <span class="stat-label">Winners:</span><span id="modalWinners" class="stat-value"></span>
                 <span class="stat-label">Winrate:</span><span id="modalWinrate" class="stat-value"></span>
-            </div>
-            <div class="stats-row">
                 <span class="stat-label">Losers:</span><span id="modalLosers" class="stat-value"></span>
                 <span class="stat-label">Volume:</span><span id="modalVolume" class="stat-value"></span>
                 <span class="stat-label">Profit Factor:</span><span id="modalProfitFactor" class="stat-value"></span>
@@ -166,10 +168,6 @@
                 <tbody id="tradesTableBody">
                 </tbody>
             </table>
-        </div>
-        <div class="trade-nav">
-            <button class="nav-arrow left" id="prevTradeDay">&larr;</button>
-            <button class="nav-arrow right" id="nextTradeDay">&rarr;</button>
         </div>
     </div>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -1029,7 +1029,7 @@ button svg {
     font-size: 24px;
     position: absolute;
     right: 10px;
-    top: 10px;
+    top: 5px;
     padding: 0;
     width: 30px;
     height: 30px;
@@ -1582,7 +1582,7 @@ button svg {
     font-size: 24px;
     position: absolute;
     right: 10px;
-    top: 10px;
+    top: 5px;
     padding: 0;
     width: 30px;
     height: 30px;
@@ -2185,6 +2185,12 @@ button svg {
     margin-bottom: 10px;
 }
 
+.modal-header .date-nav {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 .modal-date {
     font-size: 24px;
     font-weight: 600;
@@ -2204,9 +2210,9 @@ button svg {
 
 .trade-stats .stats-row {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 15px;
-    margin-bottom: 5px;
+    align-items: flex-end;
 }
 
 .trade-stats .stat-label {
@@ -2242,11 +2248,7 @@ button svg {
     text-align: left;
 }
 
-.trade-nav {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 10px;
-}
+/* Removed .trade-nav since navigation arrows moved to header */
 
 .nav-arrow {
     background: transparent;
@@ -2261,7 +2263,7 @@ button svg {
     font-size: 24px;
     position: absolute;
     right: 10px;
-    top: 10px;
+    top: 5px;
     padding: 0;
     width: 30px;
     height: 30px;


### PR DESCRIPTION
## Summary
- 将前后导航箭头移至日期两侧，支持在工作日之间切换
- 统一统计行布局并补充 Volume 与 Profit Factor
- 上移关闭按钮避免遮挡净利润

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf778097e8832e8ff00766350ccfff